### PR TITLE
EditorContainer 추가

### DIFF
--- a/src/components/containers/write/EditorContainer.tsx
+++ b/src/components/containers/write/EditorContainer.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { ReducerType } from "../../../modules";
+import { changeField, initialize } from "../../../modules/write";
+import Editor from "../../write/Editor";
+
+const EditorContainer = () => {
+  const dispatch = useDispatch();
+  const { title, body } = useSelector(({ write }: ReducerType) => ({
+    title: write.title,
+    body: write.body,
+  }));
+
+  const onChangeField = useCallback(
+    (paylaod) => dispatch(changeField(paylaod)),
+    [dispatch],
+  );
+
+  // componentDidUnmount 시 초기화
+  useEffect(() => {
+    return () => {
+      dispatch(initialize());
+    };
+  }, [dispatch]);
+
+  return <Editor onChangeField={onChangeField} title={title} body={body} />;
+};
+
+export default EditorContainer;

--- a/src/components/write/Editor.tsx
+++ b/src/components/write/Editor.tsx
@@ -1,10 +1,16 @@
-import React, { useEffect, useRef } from "react";
+import React, { ChangeEvent, useEffect, useRef } from "react";
 import Quill from "quill";
 import "quill/dist/quill.bubble.css";
 import "quill/dist/quill.snow.css";
 import "../write/Editor.scss";
 
-const Editor = () => {
+interface editorType {
+  onChangeField: any;
+  title: string;
+  body: string;
+}
+
+const Editor = ({ onChangeField, title, body }: editorType) => {
   const quillInstance = useRef<any>(null);
   const quillElement = useRef<any>(null);
   useEffect(() => {
@@ -22,8 +28,18 @@ const Editor = () => {
         },
       },
     });
-    quillInstance.current.setContents(null);
-  }, []);
+    const quill = quillInstance.current;
+    quill.setContents(null);
+    quill.on("text-change", (delta: any, oldDelta: any, source: any) => {
+      if (source === "user") {
+        onChangeField({ key: "body", value: quill.root.innerHTML });
+      }
+    });
+  }, [onChangeField]);
+
+  const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    onChangeField({ key: "title", value: e.target.value });
+  };
 
   return (
     <div className="editor-block">
@@ -31,6 +47,8 @@ const Editor = () => {
         type="text"
         className="title-input"
         placeholder="제목을 입력하세요."
+        onChange={onChangeTitle}
+        value={title}
       />
       <div className="quill-wrapper">
         <div ref={quillElement}></div>

--- a/src/modules/write.ts
+++ b/src/modules/write.ts
@@ -13,7 +13,7 @@ export const changeField = ({
 }: {
   key: string;
   value: string;
-}) => ({ type: CHANGE_FIELD, key, value });
+}) => ({ type: CHANGE_FIELD, payload: { key, value } });
 
 const initialState = {
   title: "",
@@ -30,6 +30,7 @@ const write = (
       return initialState;
     case CHANGE_FIELD:
       return produce(state, (draft) => {
+        console.log("action:", action);
         draft[action.payload.key as keyof initializeStateType] =
           action.payload.value;
       });

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Responsive } from "../components/common/Responsive";
 import TagBox from "../components/common/TagBox/TagBox";
-import Editor from "../components/write/Editor";
+import EditorContainer from "../components/containers/write/EditorContainer";
 import WriteActionButtons from "../components/write/WriteActionButtons";
 
 const WritePage = () => {
   return (
     <Responsive>
-      <Editor />
+      <EditorContainer />
       <TagBox />
       <WriteActionButtons />
     </Responsive>


### PR DESCRIPTION
- EditorContainer 추가 

> onChangeField함수 useCallback으로 감싼이유: 
 Editor에서 사용할 useEffect가 컴포넌트 화면에 나타났을 때 딱 한 번만 실행하기위해 사용 